### PR TITLE
Allow missing dependencies while installing the base app

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ function ensrueRef (options, flatpakref, id, version) {
         if (!flatpakref) throw new Error(`Cannot install ${id} without flatpakref`)
         let args = ['install']
         addCommandLineOption(args, 'user', true)
+        addCommandLineOption(args, 'no-deps', true)
         addCommandLineOption(args, 'arch', options['arch'])
         addCommandLineOption(args, 'from', flatpakref)
         return spawnWithLogging(options, 'flatpak', args)
@@ -116,6 +117,7 @@ function ensrueRef (options, flatpakref, id, version) {
       logger(`Found install of ${id}, trying to update`)
       let args = ['update']
       if (userInstall) addCommandLineOption(args, 'user', true)
+      addCommandLineOption(args, 'no-deps', true)
       addCommandLineOption(args, 'arch', options['arch'])
       args.push(id)
       if (version) args.push(version)


### PR DESCRIPTION
flatpak-bundler can be used to just shuffle files into a flatpak
without actually building anything. This is particularly useful for
building electron like apps which are just dealing with precompiled
binaries.

In that case we don't really need the sdk or platform around, and
should support them being missing. We can do this by passing the
--no-deps flag command while autoinstalling the base app.

https://phabricator.endlessm.com/T14918